### PR TITLE
Debug keypad for mobile

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:math_expressions/math_expressions.dart';
+import 'package:universal_html/html.dart' as html;
 
 import './widgets/keypad.dart';
 import './widgets/past_eval.dart';
@@ -9,7 +10,9 @@ void main() {
   runApp(MyApp());
 }
 
-//TODO maybe try to implement a way to click and change the text
+//TODO try to implement a way to click and change the text
+//TODO fix remaining bug about accessing web app on mobile browser directly on
+//TODO reflow the widgets when the screen is rotated sideways
 
 class MyApp extends StatelessWidget {
   // This widget is the root of your application.
@@ -158,6 +161,23 @@ class _MyHomePageState extends State<MyHomePage> {
     });
   }
 
+  String _getMobile() {
+    /* This method returns the browser type as a string. 
+    "mobile" if the app is running on a mobile browser
+    "desktop" if the app is running on a desktop browser
+    credits to this answer: https://github.com/flutter/flutter/issues/41311
+    */
+    final userAgent = html.window.navigator.userAgent.toString().toLowerCase();
+    // smartphone
+    if (userAgent.contains("iphone")) {
+      return "mobile";
+    } else if (userAgent.contains("android")) {
+      return "mobile";
+    } else {
+      return "desktop";
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final appBar = AppBar(
@@ -181,7 +201,8 @@ class _MyHomePageState extends State<MyHomePage> {
       appBar: appBar,
       body: Center(
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.end,
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
             // Past Eval box
             Container(
@@ -227,40 +248,59 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
             ),
 
-            // Testing Container
-            Container(
-              padding: EdgeInsets.all(padKey1),
-              height: (MediaQuery.of(context).size.height -
-                          appBar.preferredSize.height -
-                          MediaQuery.of(context).padding.top) *
-                      0.40 -
-                  (2 * padKey1),
-              width: widthOfWidgets,
-              decoration:
-                  BoxDecoration(border: Border.all(color: Colors.blueAccent)),
-              child: Text('My Awesome Border'),
-            ),
-
-            // Keyboard
-            // Container(
-            //   padding: EdgeInsets.all(padKey1),
-            //   height: (MediaQuery.of(context).size.height -
-            //               appBar.preferredSize.height -
-            //               MediaQuery.of(context).padding.top) *
-            //           0.40 -
-            //       (2 * padKey1),
-            //   width: widthOfWidgets,
-            //   child: LayoutBuilder(
-            //     builder: (BuildContext cxt, BoxConstraints constraints) {
-            //       return Keypad(
-            //         btnArr: BtnGrid().keypad,
-            //         genParam: BtnGrid().keypadParam,
-            //         size: [constraints.maxWidth, constraints.maxHeight],
-            //         onPressed: _currTxt,
-            //       );
-            //     },
-            //   ),
-            // ),
+            /* 
+            The following code chunk is to fix a weird bug where the keypad 
+            widget would not display properly. The remaining bug is accessing 
+            the web app with a mobile browser using the direct github.io link.
+            If the web app is embedded in a webpage it is properly displayed.
+            */
+            _getMobile() == "mobile"
+                ? Container(
+                    margin: EdgeInsets.symmetric(
+                        vertical: pad, horizontal: pad + 3),
+                    //decoration: BoxDecoration(
+                    //  border: Border.all(color: Colors.blueAccent)),
+                    child: Column(
+                      children: [
+                        Keypad(
+                          btnArr: BtnGrid().keypad,
+                          genParam: BtnGrid().keypadParam,
+                          size: [
+                            widthOfWidgets - 15 - 40,
+                            (MediaQuery.of(context).size.height -
+                                        appBar.preferredSize.height -
+                                        MediaQuery.of(context).padding.top -
+                                        100) *
+                                    0.40 -
+                                (2 * padKey1) -
+                                40
+                          ],
+                          onPressed: _currTxt,
+                        ),
+                        SizedBox(height: double.infinity),
+                      ],
+                    ),
+                  )
+                : Container(
+                    margin: EdgeInsets.symmetric(
+                        vertical: pad, horizontal: pad + 3),
+                    //decoration: BoxDecoration(
+                    //  border: Border.all(color: Colors.amberAccent)),
+                    child: Keypad(
+                      btnArr: BtnGrid().keypad,
+                      genParam: BtnGrid().keypadParam,
+                      size: [
+                        widthOfWidgets - 15,
+                        (MediaQuery.of(context).size.height -
+                                    appBar.preferredSize.height -
+                                    MediaQuery.of(context).padding.top -
+                                    100) *
+                                0.40 -
+                            (2 * padKey1)
+                      ],
+                      onPressed: _currTxt,
+                    ),
+                  ),
           ],
         ),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -171,6 +171,7 @@ class _MyHomePageState extends State<MyHomePage> {
     final EdgeInsets cardMargins =
         EdgeInsets.symmetric(vertical: pad, horizontal: pad + 3);
 
+    // This is the standard width for widgets on the page
     final double widthOfWidgets =
         MediaQuery.of(context).size.width - (2 * padKey1);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -171,6 +171,9 @@ class _MyHomePageState extends State<MyHomePage> {
     final EdgeInsets cardMargins =
         EdgeInsets.symmetric(vertical: pad, horizontal: pad + 3);
 
+    final double widthOfWidgets =
+        MediaQuery.of(context).size.width - (2 * padKey1);
+
     _currFontSize();
 
     return Scaffold(
@@ -185,7 +188,7 @@ class _MyHomePageState extends State<MyHomePage> {
                       appBar.preferredSize.height -
                       MediaQuery.of(context).padding.top) *
                   0.50,
-              width: MediaQuery.of(context).size.width - (2 * padKey1),
+              width: widthOfWidgets,
               child: PastEval(
                 pastEvals: _pastEvals,
                 margin: cardMargins,
@@ -230,7 +233,7 @@ class _MyHomePageState extends State<MyHomePage> {
                           MediaQuery.of(context).padding.top) *
                       0.40 -
                   (2 * padKey1),
-              width: MediaQuery.of(context).size.width - (2 * padKey1),
+              width: widthOfWidgets,
               child: LayoutBuilder(
                 builder: (BuildContext cxt, BoxConstraints constraints) {
                   return Keypad(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -226,7 +226,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
               ),
             ),
-            // Keyboard
+
+            // Testing Container
             Container(
               padding: EdgeInsets.all(padKey1),
               height: (MediaQuery.of(context).size.height -
@@ -235,17 +236,31 @@ class _MyHomePageState extends State<MyHomePage> {
                       0.40 -
                   (2 * padKey1),
               width: widthOfWidgets,
-              child: LayoutBuilder(
-                builder: (BuildContext cxt, BoxConstraints constraints) {
-                  return Keypad(
-                    btnArr: BtnGrid().keypad,
-                    genParam: BtnGrid().keypadParam,
-                    size: [constraints.maxWidth, constraints.maxHeight],
-                    onPressed: _currTxt,
-                  );
-                },
-              ),
+              decoration:
+                  BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+              child: Text('My Awesome Border'),
             ),
+
+            // Keyboard
+            // Container(
+            //   padding: EdgeInsets.all(padKey1),
+            //   height: (MediaQuery.of(context).size.height -
+            //               appBar.preferredSize.height -
+            //               MediaQuery.of(context).padding.top) *
+            //           0.40 -
+            //       (2 * padKey1),
+            //   width: widthOfWidgets,
+            //   child: LayoutBuilder(
+            //     builder: (BuildContext cxt, BoxConstraints constraints) {
+            //       return Keypad(
+            //         btnArr: BtnGrid().keypad,
+            //         genParam: BtnGrid().keypadParam,
+            //         size: [constraints.maxWidth, constraints.maxHeight],
+            //         onPressed: _currTxt,
+            //       );
+            //     },
+            //   ),
+            // ),
           ],
         ),
       ),

--- a/lib/widgets/past_eval.dart
+++ b/lib/widgets/past_eval.dart
@@ -25,7 +25,7 @@ class PastEval extends StatelessWidget {
               title: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  Text("No past history..."),
+                  Text("No past history...04"),
                 ],
               ),
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,6 +43,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -67,6 +81,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.0"
   matcher:
     dependency: transitive
     description:
@@ -149,6 +170,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  universal_html:
+    dependency: "direct main"
+    description:
+      name: universal_html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.8"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
   math_expressions: ^2.1.1
+  universal_html: ^2.0.8
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
The following code is to fix a weird bug where the keypad widget would not display properly. The remaining bug is accessing the web app with a mobile browser using the direct github.io link. If the web app is embedded in a webpage it is properly displayed.

The way that it does so is by detecting via the userAgent if the client is a mobile or a desktop device and reformats the widget accordingly. The mobile reformating solution is hardcoded, I offset the keypad widget by the pixel amount that was displayed incorrectly before. Therefore there might be some revisiting to do later. I could not find an explanation for this odd behavior. 

I tried forcing a CanvasKit render instead of an automatic one (html is mobile and CanvasKit is desktop) but it did not work.